### PR TITLE
Fix refresh token when token expires

### DIFF
--- a/packt/pipelines.py
+++ b/packt/pipelines.py
@@ -11,13 +11,10 @@ from scrapy.pipelines.files import FilesPipeline
 class PacktPipeline(FilesPipeline):
     def get_media_requests(self, item, info):
         req_list = []
-        access_tk = item['access_token'][0]
-        refresh_tk = item['refresh_token'][0]
         url = item['url'][0]
         file_type = item['file_type'][0]
         # headers = {'authorization': f'Bearer {access_tk}'}
-        meta = {'access_token': access_tk, 'refresh_token': refresh_tk}
-        req = Request(url, meta=meta, priority=0)
+        req = Request(url, priority=0)
         req.meta['book_name'] = item['title'][0]
         if file_type == 'code':
             req.meta['ext'] = 'zip'

--- a/packt/settings.py
+++ b/packt/settings.py
@@ -53,6 +53,8 @@ DEFAULT_REQUEST_HEADERS = {
 #    'packt.middlewares.PacktSpiderMiddleware': 543,
 # }
 
+DUPEFILTER_CLASS = 'scrapy.dupefilters.BaseDupeFilter'
+
 # Enable or disable downloader middlewares
 # See https://doc.scrapy.org/en/latest/topics/downloader-middleware.html
 DOWNLOADER_MIDDLEWARES = {


### PR DESCRIPTION
packt use jwt access and refresh token mechanism for authorization. When token expires, request returns 401, then we need to use refresh token to update token for latter requests.